### PR TITLE
Finding Docker GID using `stat` on socket

### DIFF
--- a/docker-jenkins.sh
+++ b/docker-jenkins.sh
@@ -1,4 +1,5 @@
 #! /bin/bash -e
+DOCKER_USER_GROUP=$(stat -c '%g' /var/run/docker.sock)
 echo "Creating Docker User Group: $DOCKER_USER_GROUP"
 getent group docker-host && delgroup --quiet docker-host
 addgroup -g $DOCKER_USER_GROUP docker-host


### PR DESCRIPTION
The socket is available when `docker-jenkins.sh` is executed, then using `stat` is possible to get the group identifier for the host's socket and assign it at the container's docker group.

Using `stat` there's no need to set an environment variable or pass it trough CLI.